### PR TITLE
Small changes to read_pathoscope and associated test.

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -14,11 +14,10 @@ Imports: tidyverse,
          SummarizedExperiment,
          BiocGenerics,
          S4Vectors,
-         Phyloseq,
-         Biomformat,
+         phyloseq,
+         biomformat,
          taxize,
          magrittr
-
 Collate: GenericOmicSet-class.R
         MetaOmicSet-class.R
         uid2lineage.R

--- a/R/IO-methods.R
+++ b/R/IO-methods.R
@@ -40,12 +40,12 @@ read_pathoscope <- function(dir_file = ".",
                               pattern0 = "",
                               pattern1 = ".tsv",
                               splitPoint = "[.]"){
-  colData <- read.csv(smeta_file,
+  colData <- read.csv(paste(dir_file,smeta_file, sep="/"),
                       row.names = 1,
                       skip = 4,
                       header = T)
   for(i in rownames(colData)){
-    df <- read.csv(paste0(pattern0, i, pattern1),
+    df <- read.csv(paste0(dir_file, "/", pattern0, i, pattern1),
                    skip = 1,
                    header = T,
                    stringsAsFactors = F,

--- a/tests/testthat/test-GenericOmicSet.R
+++ b/tests/testthat/test-GenericOmicSet.R
@@ -6,7 +6,7 @@ test_that("read_pathoscope", {
   example_dir <- system.file("extdata/asthma", package = "MetaOmicSet")
   a <- read_pathoscope(dir_file = example_dir,
                                                smeta_file = "Data-PRJNA255523.csv",
-                                               pattern1 = ".filtered.fastq-sam-report.tsv",
+                                               pattern1 = ".filtered.fastq-sam-report.tsv.gz",
                                                splitPoint = "[.]")
   expect_equal(dim(a[[1]]), c(1508, 14))
   expect_equal(dim(a[[2]]), c(14, 6))


### PR DESCRIPTION
Made small but consequential changes that ensure GenericOmicTest can be run:

In GenericOmicTest class changed pattern1 to include the '.gz' extension

In IO-methods class, added two references to 'dir_file' which was not previously being called.